### PR TITLE
Add survival mode compatibility and other features

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -82,7 +82,27 @@ esac
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
-JAVACMD="/home/ahydul/Documents/Programming/java-jdk-17/bin/java"
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
 
 # Increase the maximum file descriptors if we can.
 if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then

--- a/gradlew
+++ b/gradlew
@@ -82,27 +82,7 @@ esac
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
-# Determine the Java command to use to start the JVM.
-if [ -n "$JAVA_HOME" ] ; then
-    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
-        # IBM's JDK on AIX uses strange locations for the executables
-        JAVACMD="$JAVA_HOME/jre/sh/java"
-    else
-        JAVACMD="$JAVA_HOME/bin/java"
-    fi
-    if [ ! -x "$JAVACMD" ] ; then
-        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
-
-Please set the JAVA_HOME variable in your environment to match the
-location of your Java installation."
-    fi
-else
-    JAVACMD="java"
-    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-
-Please set the JAVA_HOME variable in your environment to match the
-location of your Java installation."
-fi
+JAVACMD="/home/ahydul/Documents/Programming/java-jdk-17/bin/java"
 
 # Increase the maximum file descriptors if we can.
 if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then

--- a/src/main/java/space/essem/image2map/Image2Map.java
+++ b/src/main/java/space/essem/image2map/Image2Map.java
@@ -100,6 +100,13 @@ public class Image2Map implements ModInitializer {
 
     private int openPreview(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
+
+        PlayerEntity player = source.getPlayer();
+        if (!CONFIG.allowSurvivalMode && !player.getAbilities().creativeMode) {
+            player.sendMessage(Text.literal("You are not allowed to use this command.").formatted(Formatting.RED));
+            return 1;
+        }
+
         String input = StringArgumentType.getString(context, "path");
 
         source.sendFeedback(() -> Text.literal("Getting image..."), false);
@@ -173,6 +180,7 @@ public class Image2Map implements ModInitializer {
 
         if (!CONFIG.allowSurvivalMode && !player.getAbilities().creativeMode) {
             player.sendMessage(Text.literal("You are not allowed to use this command.").formatted(Formatting.RED));
+            return 1;
         }
 
         DitherMode mode;

--- a/src/main/java/space/essem/image2map/Image2Map.java
+++ b/src/main/java/space/essem/image2map/Image2Map.java
@@ -15,6 +15,7 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.decoration.ItemFrameEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
@@ -255,6 +256,15 @@ public class Image2Map implements ModInitializer {
    
     }
 
+    private static void giveItemStackToPlayer(ItemStack itemStack, PlayerEntity player) {
+        if (player.getInventory().getEmptySlot() == -1) {
+            player.dropStack(itemStack);
+        }
+        else {
+            player.giveItemStack(itemStack);
+        }
+    }
+
     public static void giveToPlayer(PlayerEntity player, List<ItemStack> items, String input, int width, int height, Boolean useBundle) {
         if (!player.getAbilities().creativeMode) {
             PlayerInventory inventory = player.getInventory();
@@ -278,13 +288,13 @@ public class Image2Map implements ModInitializer {
 
         if (!useBundle) {
             for (ItemStack item:items) {
-                player.giveItemStack(item);
+                giveItemStackToPlayer(item, player);
             }
             return;
         }
 
         if (items.size() == 1) {
-            player.giveItemStack(items.get(0));
+            giveItemStackToPlayer(items.get(0), player);
         } else {
             var bundle = new ItemStack(Items.BUNDLE);
             var list = new NbtList();
@@ -302,7 +312,7 @@ public class Image2Map implements ModInitializer {
             bundle.getOrCreateSubNbt("display").put("Lore", lore);
             bundle.setCustomName(Text.literal("Maps").formatted(Formatting.GOLD));
 
-            player.giveItemStack(bundle);
+            giveItemStackToPlayer(bundle, player);
         }
     }
 

--- a/src/main/java/space/essem/image2map/config/Image2MapConfig.java
+++ b/src/main/java/space/essem/image2map/config/Image2MapConfig.java
@@ -18,6 +18,8 @@ public class Image2MapConfig {
 
   public int minPermLevel = 2;
 
+  public boolean allowSurvivalMode = true;
+
 
   public static Image2MapConfig loadOrCreateConfig() {
     try {

--- a/src/main/java/space/essem/image2map/gui/PreviewGui.java
+++ b/src/main/java/space/essem/image2map/gui/PreviewGui.java
@@ -33,6 +33,7 @@ public class PreviewGui extends MapGui {
     private Image2Map.DitherMode ditherMode;
     private int width;
     private int height;
+    private boolean useBundle = true;
     private boolean grid = true;
     private CompletableFuture<CanvasImage> imageProcessing;
 
@@ -149,6 +150,18 @@ public class PreviewGui extends MapGui {
         this.updateImage();
     }
 
+    public void setSize(int size) {
+        int sourceWidth = this.sourceImage.getWidth();
+        int sourceHeight = this.sourceImage.getHeight();
+        size = size > 8 ? 8*128 : size*128;
+
+        if (sourceWidth > sourceHeight) {
+            setSize(size, sourceHeight*size / sourceWidth);
+        } else {
+            setSize(sourceWidth*size / sourceHeight, size);
+        }
+    }
+
     public void setDitherMode(Image2Map.DitherMode ditherMode) {
         this.ditherMode = ditherMode;
         this.updateImage();
@@ -157,6 +170,10 @@ public class PreviewGui extends MapGui {
     public void setDrawGrid(boolean grid) {
         this.grid = grid;
         this.draw();
+    }
+
+    public void setUseBundle(boolean useBundle) {
+        this.useBundle = useBundle;
     }
 
     @Override
@@ -187,7 +204,7 @@ public class PreviewGui extends MapGui {
                 x.getSource().drawLoading();
                 Image2Map.giveToPlayer(x.getSource().player,
                         MapRenderer.toVanillaItems(x.getSource().image, x.getSource().player.getServerWorld(), x.getSource().source),
-                        x.getSource().source, x.getSource().width, x.getSource().height);
+                        x.getSource().source, x.getSource().width, x.getSource().height, x.getSource().useBundle);
 
                 x.getSource().close();
             } else {
@@ -230,6 +247,26 @@ public class PreviewGui extends MapGui {
                     return 0;
                 })
         );
+
+        COMMANDS.register(literal("bundle")
+                .then(argument("value", BoolArgumentType.bool()).executes(x -> {
+                    x.getSource().setUseBundle(BoolArgumentType.getBool(x, "value"));
+                    return 0;
+                }))
+        );
+
+        COMMANDS.register(literal("normalize")
+            .then(argument("value", IntegerArgumentType.integer(1)).executes(x -> {
+                        x.getSource().setSize(IntegerArgumentType.getInteger(x, "value"));
+                        return 0;
+                    }))
+            .executes(x -> {
+                x.getSource().player.sendMessage(Text.literal("Source: " + x.getSource().sourceImage.getWidth() + " x " + x.getSource().sourceImage.getHeight()));
+                x.getSource().player.sendMessage(Text.literal("MapImage: " + x.getSource().width + " x " + x.getSource().height));
+                return 0;
+            })
+        );
+
     }
 
 }


### PR DESCRIPTION
Add to the config a way to allow survival players to use this feature.
Add an option to use bundle or not.
Add an option to normalize the size. Normalize 1 would normalize the height and width to be maximum 1 map, 2 would be 4 maps, up to 8 (64).
Fix bug related to losing items when player inventory was full. The behavior now is to spawn the items that can't go inside the inventory in the player position.